### PR TITLE
User management

### DIFF
--- a/backend/src/common/utils/query-builder.ts
+++ b/backend/src/common/utils/query-builder.ts
@@ -1,0 +1,41 @@
+import {
+  Equal,
+  Like,
+  Repository,
+  FindManyOptions,
+  FindOptionsWhere,
+  ObjectLiteral,
+} from 'typeorm';
+
+export type QueryMapping = Record<
+  string,
+  'equal' | 'like' | ((value: any) => any)
+>;
+
+export async function buildAndExecuteQuery<T extends ObjectLiteral>(
+  repository: Repository<T>,
+  query: Record<string, any>,
+  mappings: QueryMapping,
+  options?: Omit<FindManyOptions<T>, 'where'>,
+): Promise<T[]> {
+  const where: FindOptionsWhere<T> = {};
+
+  for (const key in mappings) {
+    const value = query[key];
+    if (value === undefined || value === null || value === '') continue;
+
+    const handler = mappings[key];
+    if (handler === 'equal') {
+      (where as any)[key] = Equal(value);
+    } else if (handler === 'like') {
+      (where as any)[key] = Like(`%${value.toLowerCase()}%`);
+    } else if (typeof handler === 'function') {
+      (where as any)[key] = handler(value);
+    }
+  }
+
+  return repository.find({
+    ...options,
+    where,
+  });
+}

--- a/backend/src/i18n/en/auth.json
+++ b/backend/src/i18n/en/auth.json
@@ -9,5 +9,6 @@
   "token_missing": "Reset token is missing",
   "password_too_short": "Password must be at least 6 characters long",
   "password_reset_failed": "Failed to reset password",
-  "reset_link_sent": "Reset link sent to email"
+  "reset_link_sent": "Reset link sent to email",
+  "account_inactive": "Your account has been deactivated. Please contact support."
 }

--- a/backend/src/i18n/en/user.json
+++ b/backend/src/i18n/en/user.json
@@ -28,5 +28,6 @@
   "update_failed": "Failed to update user profile",
   "change_password_failed": "Failed to change password",
   "invalid_current_password": "Current password is incorrect",
-  "change_password_success": "Password changed successfully."
+  "change_password_success": "Password changed successfully.",
+  "update_status_failed": "Failed to update user activity status."
 }

--- a/backend/src/i18n/vi/auth.json
+++ b/backend/src/i18n/vi/auth.json
@@ -9,5 +9,6 @@
   "token_missing": "Thiếu mã token để đặt lại mật khẩu",
   "password_too_short": "Mật khẩu phải có ít nhất 6 ký tự",
   "password_reset_failed": "Đặt lại mật khẩu thất bại",
-  "reset_link_sent": "Đã gửi liên kết đặt lại mật khẩu"
+  "reset_link_sent": "Đã gửi liên kết đặt lại mật khẩu",
+  "account_inactive": "Tài khoản của bạn đã bị vô hiệu hóa. Vui lòng liên hệ hỗ trợ."
 }

--- a/backend/src/i18n/vi/user.json
+++ b/backend/src/i18n/vi/user.json
@@ -28,5 +28,6 @@
   "update_failed": "Cập nhật thông tin người dùng thất bại",
   "change_password_failed": "Đổi mật khẩu thất bại",
   "invalid_current_password": "Mật khẩu hiện tại không đúng",
-  "change_password_success": "Đổi mật khẩu thành công."
+  "change_password_success": "Đổi mật khẩu thành công.",
+  "update_status_failed": "Cập nhật trạng thái hoạt động thất bại."
 }

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -37,6 +37,10 @@ export class AuthService extends BaseService {
       throw new BadRequestException(await this.t('auth.email_not_verified'));
     }
 
+    if (!user.is_active) {
+      throw new BadRequestException(await this.t('auth.account_inactive'));
+    }
+
     const payload = {
       sub: user.id,
       username: user.username,

--- a/backend/src/modules/password_reset_tokens/entities/password-reset.module.ts
+++ b/backend/src/modules/password_reset_tokens/entities/password-reset.module.ts
@@ -9,7 +9,7 @@ import { MailModule } from '@/common/jobs/mail/mail.module';
   imports: [
     TypeOrmModule.forFeature([PasswordResetToken]),
     forwardRef(() => UserModule),
-    MailModule,
+    MailModule
   ],
   controllers: [PasswordResetController],
   providers: [PasswordResetService],

--- a/backend/src/modules/questions/dto/find-question.dto.ts
+++ b/backend/src/modules/questions/dto/find-question.dto.ts
@@ -1,0 +1,22 @@
+import { IsOptional, IsNumber, IsString } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class FindQuestionDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  subject_id?: number;
+
+  @IsOptional()
+  @IsString()
+  question_type?: string;
+
+  @IsOptional()
+  @IsString()
+  question_text?: string;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  creator_id?: number;
+}

--- a/backend/src/modules/questions/question.controller.ts
+++ b/backend/src/modules/questions/question.controller.ts
@@ -9,6 +9,7 @@ import {
   ParseIntPipe,
   Req,
   UseGuards,
+  Query,
 } from '@nestjs/common';
 import { QuestionService } from './question.service';
 import { CreateQuestionDto } from './dto/create-question.dto';
@@ -38,8 +39,8 @@ export class QuestionController {
 
   @Get()
   @ApiResponseDataArray(QuestionSerializer)
-  async findAll(): Promise<ResponseData<QuestionSerializer[]>> {
-    const results = await this.questionService.findAll();
+  async findAll(@Query() query): Promise<ResponseData<QuestionSerializer[]>> {
+    const results = await this.questionService.findAll(query);
     return new ResponseData<QuestionSerializer[]>(
       results,
       HttpStatus.SUCCESS,

--- a/backend/src/modules/questions/question.service.ts
+++ b/backend/src/modules/questions/question.service.ts
@@ -14,6 +14,11 @@ import { BaseService } from '@/modules/shared/base.service';
 import { TestSessionStatus } from '@/common/enums/testSession.enum';
 import { TEST_DEFAULT_VERSION } from '@/common/constants/test.constant';
 import { validateMultipleChoiceAnswers } from '../shared/validators/answer.validator';
+import { FindQuestionDto } from './dto/find-question.dto';
+import {
+  buildAndExecuteQuery,
+  QueryMapping,
+} from 'src/common/utils/query-builder';
 
 @Injectable()
 export class QuestionService extends BaseService {
@@ -59,17 +64,28 @@ export class QuestionService extends BaseService {
   /**
    * Lấy danh sách tất cả câu hỏi.
    */
-  async findAll(): Promise<QuestionSerializer[]> {
-    const questions = await this.questionRepo.find({
-      order: { subject_id: 'ASC', id: 'ASC' },
-      relations: ['creator', 'subject', 'answers'],
-    });
+  async findAll(query?: FindQuestionDto): Promise<QuestionSerializer[]> {
+    const mappings: QueryMapping = {
+      subject_id: 'equal',
+      question_type: 'equal',
+      creator_id: 'equal',
+      question_text: 'like',
+    };
+
+    const questions = await buildAndExecuteQuery(
+      this.questionRepo,
+      query || {},
+      mappings,
+      {
+        relations: ['creator', 'subject', 'answers'],
+        order: { subject_id: 'ASC', id: 'ASC' },
+      },
+    );
 
     return plainToInstance(QuestionSerializer, questions, {
       excludeExtraneousValues: true,
     });
   }
-
   /**
    * Lấy chi tiết 1 câu hỏi theo id.
    */

--- a/backend/src/modules/users/dto/update-profile.dto.ts
+++ b/backend/src/modules/users/dto/update-profile.dto.ts
@@ -1,4 +1,4 @@
-import { IsOptional, IsString } from 'class-validator';
+import { IsOptional, IsString} from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class UpdateProfileDto {

--- a/backend/src/modules/users/dto/update-status.dto.ts
+++ b/backend/src/modules/users/dto/update-status.dto.ts
@@ -1,0 +1,8 @@
+import { IsBoolean } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UpdateStatusDto {
+  @ApiProperty()
+  @IsBoolean()
+  is_active: boolean;
+}

--- a/backend/src/modules/users/user.service.ts
+++ b/backend/src/modules/users/user.service.ts
@@ -154,7 +154,7 @@ export class UserService extends BaseService {
   ): Promise<UserSerializer> {
     try {
       const user = await this.findById(userId);
-
+      
       if (dto.full_name) {
         user.full_name = dto.full_name;
       }
@@ -218,6 +218,43 @@ export class UserService extends BaseService {
     } catch (err) {
       if (err instanceof BadRequestException) throw err;
       throw new BadRequestException(await this.t('user.fetch_failed'));
+    }
+  }
+  async getUsersList(): Promise<UserSerializer[]> {
+    try {
+      const users = await this.userRepo.find({
+        where: {
+          role: {
+            name: 'user',
+          },
+        },
+        relations: ['role'],
+        order: { id: 'ASC' },
+      });
+
+      return plainToInstance(UserSerializer, users, {
+        excludeExtraneousValues: true,
+      });
+    } catch {
+      throw new BadRequestException(await this.t('user.fetch_failed'));
+    }
+  }
+
+  async updateStatusStudent(
+    userId: number,
+    is_active: boolean,
+  ): Promise<UserSerializer> {
+    try {
+      const user = await this.findById(userId);
+      user.is_active = is_active;
+      const updatedUser = await this.userRepo.save(user);
+
+      return plainToInstance(UserSerializer, updatedUser, {
+        excludeExtraneousValues: true,
+      });
+    } catch (err) {
+      if (err instanceof BadRequestException) throw err;
+      throw new BadRequestException(await this.t('user.update_status_failed'));
     }
   }
 }

--- a/frontend/src/components/Users/UserTable.tsx
+++ b/frontend/src/components/Users/UserTable.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { Table, Tag, Switch } from "antd";
+import type { ColumnsType } from "antd/es/table";
+import type { UserSerializer } from "../../types/user.type";
+import { useTranslation } from "react-i18next";
+
+interface Props {
+  data: UserSerializer[];
+  loading: boolean;
+  onUpdateUserStatus: (
+    userId: number,
+    statusData: { is_active: boolean }
+  ) => Promise<boolean>;
+}
+
+const UserTable: React.FC<Props> = ({ data, loading, onUpdateUserStatus }) => {
+  const { t } = useTranslation("user");
+
+  const handleStatusToggle = (record: UserSerializer) => {
+    onUpdateUserStatus(record.id, { is_active: !record.is_active });
+  };
+
+  const columns: ColumnsType<UserSerializer> = [
+    { title: t("id"), dataIndex: "id", key: "id" },
+    { title: t("username"), dataIndex: "username", key: "username" },
+    { title: t("email"), dataIndex: "email", key: "email" },
+    { title: t("full_name"), dataIndex: "full_name", key: "full_name" },
+    {
+      title: t("active"),
+      key: "is_active",
+      render: (_, record) => (
+        <Tag color={record.is_active ? "green" : "red"}>
+          {record.is_active ? t("active") : t("inactive")}
+        </Tag>
+      ),
+    },
+    {
+      title: t("action"),
+      key: "action",
+      render: (_, record) => (
+        <Switch
+          checked={record.is_active}
+          onChange={() => handleStatusToggle(record)}
+        />
+      ),
+    },
+  ];
+
+  return (
+    <Table
+      columns={columns}
+      dataSource={data}
+      rowKey="id"
+      loading={loading}
+      pagination={{ pageSize: 8 }}
+    />
+  );
+};
+
+export default UserTable;

--- a/frontend/src/hooks/useQuestion.ts
+++ b/frontend/src/hooks/useQuestion.ts
@@ -23,10 +23,15 @@ export const useQuestions = () => {
   const { t } = useTranslation("question");
   const { token } = useAuth();
 
-  const loadQuestions = async () => {
+  const loadQuestions = async (filters?: {
+    subject_id?: number;
+    question_type?: string;
+    question_text?: string;
+    creator_id?: number;
+  }) => {
     setLoading(true);
     try {
-      const data = await getAllQuestions();
+      const data = await getAllQuestions(filters);
       setQuestions(data.data || []);
     } catch (err) {
       toast.error((err as Error).message);

--- a/frontend/src/i18n/en/question.json
+++ b/frontend/src/i18n/en/question.json
@@ -43,5 +43,14 @@
   "explanation_required": "Please provide explanation for the correct answer",
   "version": "Version",
   "latest": "Latest",
-  "old_version": "Old Version"
+  "old_version": "Old Version",
+    "subject": "Subject",
+  "type": "Question type",
+  "select_type": "Select question type",
+  "content": "Question content",
+  "search_by_content": "Search by content",
+  "creator": "Creator",
+  "search": "Search",
+  "reset": "Reset",
+  "select_creator": "Select creator"
 }

--- a/frontend/src/i18n/en/supervisor.json
+++ b/frontend/src/i18n/en/supervisor.json
@@ -5,5 +5,6 @@
   "tests": "Student Tests",
   "logout": "Logout",
   "profile": "Profile",
-  "test_management": "Manage Tests"
+  "test_management": "Manage Tests",
+  "users_management": "Student"
 }

--- a/frontend/src/i18n/en/user.json
+++ b/frontend/src/i18n/en/user.json
@@ -23,5 +23,10 @@
   "enter_full_name": "Enter full name",
   "invalid_image_format": "Please select a valid image format",
   "cancel": "Cancel",
-  "username": "Username"
+  "username": "Username",
+  "id": "ID",
+  "active": "Active",
+  "inactive": "Inactive",
+  "update_status_success": "User status updated successfully",
+  "action": "Action"
 }

--- a/frontend/src/i18n/vi/question.json
+++ b/frontend/src/i18n/vi/question.json
@@ -43,5 +43,15 @@
   "explanation_required": "Vui lòng nhập giải thích cho đáp án đúng",
   "version": "Phiên bản",
   "latest": "Mới nhất",
-  "old_version": "Đã cũ"
+  "old_version": "Đã cũ",
+  "subject": "Môn học",
+  "type": "Loại câu hỏi",
+  "select_type": "Chọn loại câu hỏi",
+  "content": "Nội dung câu hỏi",
+  "search_by_content": "Tìm theo nội dung",
+  "creator": "Người tạo",
+  "creator_id": "ID người tạo",
+  "search": "Tìm kiếm",
+  "reset": "Đặt lại",
+  "select_creator": "Chọn người tạo"
 }

--- a/frontend/src/i18n/vi/supervisor.json
+++ b/frontend/src/i18n/vi/supervisor.json
@@ -5,5 +5,6 @@
   "tests": "Bài làm của học viên",
   "logout": "Đăng xuất",
   "profile": "Trang cá nhân",
-  "test_management": "Bài thi"
+  "test_management": "Bài thi",
+  "users_management": "Học viên"
 }

--- a/frontend/src/i18n/vi/user.json
+++ b/frontend/src/i18n/vi/user.json
@@ -23,5 +23,10 @@
   "enter_full_name": "Nhập họ và tên",
   "invalid_image_format": "Vui lòng chọn đúng định dạng ảnh",
   "cancel": "Hủy",
-  "username": "Tên đăng nhập"
+  "username": "Tên đăng nhập",
+  "id": "Mã học viên",
+  "active": "Hoạt động",
+  "inactive": "Không hoạt động",
+  "update_status_success": "Cập nhật trạng thái người dùng thành công",
+  "action": "Hành động"
 }

--- a/frontend/src/layouts/SuppervisorLayout.tsx
+++ b/frontend/src/layouts/SuppervisorLayout.tsx
@@ -44,6 +44,11 @@ const SupervisorLayout = () => {
       label: t("tests"),
       onClick: () => navigate("/suppervisor/tests"),
     },
+    {
+      key: "users",
+      label: t("users_management"),
+      onClick: () => navigate("/suppervisor/users"),
+    },
   ];
 
   const avatarDropdownItems = [

--- a/frontend/src/pages/suppervisor/UserManagement.tsx
+++ b/frontend/src/pages/suppervisor/UserManagement.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import UserTable from "../../components/Users/UserTable";
+import { useUser } from "../../hooks/useUser";
+
+const UserManagement: React.FC = () => {
+  const { usersList, loadingUsersList, onUpdateUserStatus } = useUser();
+
+  return (
+    <UserTable
+      data={usersList}
+      loading={loadingUsersList}
+      onUpdateUserStatus={onUpdateUserStatus}
+    />
+  );
+};
+
+export default UserManagement;

--- a/frontend/src/routes/AppRouter.tsx
+++ b/frontend/src/routes/AppRouter.tsx
@@ -25,6 +25,7 @@ import TestResultDetailHistory from "../pages/user/TestResultDetailHistory";
 import ProfilePage from "../pages/user/ProfilePage";
 import "react-toastify/dist/ReactToastify.css";
 import ResetPasswordPage from "../pages/auth/ResetPasswordPage";
+import UserManagement from "../pages/suppervisor/UserManagement";
 const AppRouter = () => {
   return (
     <>
@@ -67,6 +68,7 @@ const AppRouter = () => {
                 path="/suppervisor/tests/:sessionId"
                 element={<TestReviewDetail />}
               />
+              <Route path="/suppervisor/users" element={<UserManagement />} />
             </Route>
           </Route>
 

--- a/frontend/src/services/questionService.ts
+++ b/frontend/src/services/questionService.ts
@@ -9,9 +9,14 @@ import type {
 } from "../types/question.type";
 import { handleAxiosError } from "../utils/handleError";
 
-export const getAllQuestions = async (): Promise<QuestionResponseAll> => {
+export const getAllQuestions = async (params?: {
+  subject_id?: number;
+  question_type?: string;
+  question_text?: string;
+  creator_id?: number;
+}): Promise<QuestionResponseAll> => {
   try {
-    const res = await api.get("/questions");
+    const res = await api.get("/questions", { params });
     return res.data;
   } catch (err) {
     throw handleAxiosError(err, "question.fetch_all_failed");

--- a/frontend/src/services/userService.ts
+++ b/frontend/src/services/userService.ts
@@ -7,6 +7,9 @@ import type {
   UpdateProfileResponse,
   ChangePasswordResponse,
   UserSerializer,
+  UserListResponse,
+  UpdateUserStatusResponse,
+  UpdateUserStatusDto,
 } from "../types/user.type";
 
 export const getUserProfile = async (): Promise<UserSerializer> => {
@@ -45,5 +48,26 @@ export const changePassword = async (
     return res.data;
   } catch (err) {
     throw handleAxiosError(err, "user.change_password_failed");
+  }
+};
+
+export const getUsersList = async (): Promise<UserListResponse> => {
+  try {
+    const res = await api.get("/users/user-list");
+    return res.data;
+  } catch (err) {
+    throw handleAxiosError(err, "user.fetch_users_failed");
+  }
+};
+
+export const updateUserStatus = async (
+  id: number,
+  data: UpdateUserStatusDto
+): Promise<UpdateUserStatusResponse> => {
+  try {
+    const res = await api.put(`/users/${id}/status`, data);
+    return res.data;
+  } catch (err) {
+    throw handleAxiosError(err, "user.update_status_failed");
   }
 };

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -52,6 +52,38 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/users/user-list": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["UserController_findAll"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/users/{id}/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put: operations["UserController_updateStatus"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/emailVerify/confirm": {
         parameters: {
             query?: never;
@@ -576,6 +608,9 @@ export interface components {
             current_password: string;
             new_password: string;
         };
+        UpdateStatusDto: {
+            is_active: boolean;
+        };
         LoginDto: {
             username: string;
             password: string;
@@ -791,6 +826,66 @@ export interface operations {
                 content: {
                     "application/json": {
                         data?: components["schemas"]["MessageResponseDto"];
+                        /** @example 200 */
+                        statusCode?: number;
+                        /** @example Server Response Success */
+                        message?: string;
+                        /** @example null */
+                        error?: string | null;
+                    };
+                };
+            };
+        };
+    };
+    UserController_findAll: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data?: components["schemas"]["UserSerializer"][];
+                        /** @example 200 */
+                        statusCode?: number;
+                        /** @example Server Response Success */
+                        message?: string;
+                        /** @example null */
+                        error?: string | null;
+                    };
+                };
+            };
+        };
+    };
+    UserController_updateStatus: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateStatusDto"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data?: components["schemas"]["UserSerializer"];
                         /** @example 200 */
                         statusCode?: number;
                         /** @example Server Response Success */

--- a/frontend/src/types/user.type.ts
+++ b/frontend/src/types/user.type.ts
@@ -17,6 +17,8 @@ export interface ProfileFormValues {
   }[];
 }
 
+export type UpdateUserStatusDto = components["schemas"]["UpdateStatusDto"];
+
 export interface ChangePasswordFormData {
   current_password: string;
   new_password: string;
@@ -27,3 +29,9 @@ export type UpdateProfileResponse =
 
 export type ChangePasswordResponse =
   paths["/users/change-password"]["put"]["responses"]["200"]["content"]["application/json"];
+
+export type UserListResponse =
+  paths["/users/user-list"]["get"]["responses"]["200"]["content"]["application/json"];
+
+export type UpdateUserStatusResponse =
+  paths["/users/{id}/status"]["put"]["responses"]["200"]["content"]["application/json"];


### PR DESCRIPTION
## Checklist tự review pull trước khi ready để trainer review
- [ ] Kiểm tra mỗi pull request chỉ 1 commit, nếu nhiều hơn 1 commit thì hãy gộp commit thành 1 rồi đẩy lại lên git
- [ ] Chạy eslint ở local để check và fix các lỗi liên quan đến syntax, coding convention. Khi gửi thì chụp ảnh PASS eslint đính kèm trong pull
- [ ] Sử dụng thụt lề 2 spaces/4 spaces đồng nhất ở tất cả các files (setting lại vscode /sublime text nếu chưa cài đặt)
- [ ] Cuối mỗi file kiểm tra có end line (khi đẩy lên git xem file change không bị lỗi tròn đỏ ở cuối file)
- [ ] Mỗi dòng nếu quá dài, cần xuống dòng (maximum: 80 kí tự mỗi dòng, setting trong IDE hoặc dùng Prettier để config format code)
- [ ] Tham khảo Typescript coding convention https://google.github.io/styleguide/tsguide.html

## Related Tickets
- Ticket [https://edu-redmine.sun-asterisk.vn/issues/88302] [Supervisor] Quản lý người dùng (xem danh sách, xem chi tiết, active/inactive người dùng)
- Ticket [https://edu-redmine.sun-asterisk.vn/issues/88303] [Supervisor] Tìm kiếm câu hỏi theo subject, type, content và người tạo

## WHAT

###  Ticket #88302 - Quản lý người dùng
- Hiển thị danh sách người dùng với các thông tin cơ bản như họ tên, email, vai trò, trạng thái hoạt động.
- Cho phép chuyển đổi trạng thái **active/inactive** ngay trong danh sách.

###  Ticket #88303 - Tìm kiếm và lọc câu hỏi
- Thêm các bộ lọc: theo **subject**, **question_type**, **content** và **creator**.
- Khi chọn lọc, kết quả bảng dữ liệu thay đổi tương ứng với tiêu chí tìm kiếm.

## HOW

###  Ticket #88302 - Quản lý người dùng
- Tạo màn hình quản lý người dùng.
- Gọi API `/api/users` để lấy danh sách toàn bộ user.
- Hiển thị nút chuyển trạng thái Active/Inactive.
- Đổi trạng thái qua API `PATCH /api/users/:id/status`.

###  Ticket #88303 - Tìm kiếm và lọc câu hỏi
- Tái sử dụng hook `useQuestions()` để fetch toàn bộ danh sách câu hỏi.
- Từ dữ liệu trả về:
  - Trích xuất danh sách các `question_type` duy nhất.
  - Trích xuất danh sách các `creator_id` duy nhất và ánh xạ sang tên.
- Cập nhật component lọc để render `<Select>` cho từng trường.
- Cập nhật table hiển thị kết quả đúng theo bộ lọc người dùng đã chọn.
- Dữ liệu trả về từ backend đã bao gồm sẵn `question_type` và `creator_id`, không cần gọi thêm API riêng.


## WHY (optional)
- Cho phép quản trị viên kiểm soát quyền truy cập của người dùng trong hệ thống.
- Hỗ trợ tắt nhanh tài khoản người dùng có hành vi vi phạm hoặc không còn sử dụng.
- Giúp Supervisor dễ dàng tìm câu hỏi phục vụ cho việc xem lại, chỉnh sửa hoặc duyệt.
- Tăng trải nghiệm người dùng với bộ lọc thân thiện, sử dụng ngay dữ liệu có sẵn, tránh gọi API thừa.

## Evidence (Screenshot or Video)
- Link youtube: https://www.youtube.com/watch?v=rJHxMzCh8XA

